### PR TITLE
update README.md, generate .svg file is better

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 This is a module dependency visualizer for go mod.
 
-## Linux 
+## Linux
 
 ```bash
+$ # Ubuntu/Debian
 $ sudo apt-get install graphviz
+$ # ArchLinux
+$ sudo pacman -S --needed graphviz
 $ go install github.com/poloxue/modv
-$ go mod graph | modv | dot -T png | display
+$ go mod graph | modv | dot -T svg -o /tmp/modv.svg && xdg-open /tmp/modv.svg
 ```
 
 ## MacOS
@@ -13,13 +16,15 @@ $ go mod graph | modv | dot -T png | display
 ```bash
 $ brew install graphviz
 $ go install github.com/poloxue/modv
-$ go mod graph | modv | dot -T png | open -f -a /Applications/Preview.app
+$ go mod graph | modv | dot -T svg | open -f -a /Applications/Preview.app
 ```
 
 ## Windows
 
 ```bash
 $ choco install graphviz.portable
+$ # for MSYS2 https://www.msys2.org/
+$ pacman -S mingw-w64-x86_64-graphviz
 $ go install github.com/poloxue/modv
-$ go mod graph | modv | dot -T png -o graph.png; start graph.png
+$ go mod graph | modv | dot -T svg -o graph.svg; start graph.svg
 ```


### PR DESCRIPTION
dot generate svg file for the project just took 0.269s,
but took 5.286s for png file
and also , svg is better for resizing the image.

the `display` command from imagemagick package is not good at displaying huge image, 
so it's better to use xdg-open let the Desktop environment to choose

```
❯ time go mod graph | modv | dot -T svg | display
go mod graph  0.06s user 0.03s system 186% cpu 0.048 total
modv  0.01s user 0.00s system 10% cpu 0.051 total
dot -T svg  0.22s user 0.01s system 83% cpu 0.269 total
display  46.03s user 4.21s system 215% cpu 23.267 total
```


```
❯ time go mod graph | modv | dot -T png | display
go mod graph  0.07s user 0.02s system 178% cpu 0.051 total
modv  0.00s user 0.00s system 10% cpu 0.054 total
dot -T png  5.12s user 0.11s system 99% cpu 5.276 total
display  39.50s user 3.75s system 156% cpu 27.591 total
```

